### PR TITLE
Public Beta Version 1.26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Inferno Collection Weapons Version 1.22 Alpha
+# Inferno Collection Weapons Version 1.23 Alpha
 #
 # Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Inferno Collection Weapons Version 1.24 Alpha
+# Inferno Collection Weapons Version 1.25 Alpha
 #
 # Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Inferno Collection Weapons Version 1.25 Alpha
+# Inferno Collection Weapons Version 1.26 Alpha
 #
 # Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Inferno Collection Weapons Version 1.26 Alpha
+# Inferno Collection Weapons Version 1.26 Beta
 #
 # Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Inferno Collection Weapons Version 1.21 Beta
+# Inferno Collection Weapons Version 1.22 Alpha
 #
 # Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Inferno Collection Weapons Version 1.23 Alpha
+# Inferno Collection Weapons Version 1.24 Alpha
 #
 # Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 #

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Inferno Collection: Weapons
 [![Build Status](https://travis-ci.com/inferno-collection/Weapons.svg?branch=master)](https://travis-ci.com/inferno-collection/Weapons)
 
-__Public Alpha Version 1.23__
+__Public Beta Version 1.26__
 
 Adds fire modes to the weapons of your choice, as well as more realistic reloads (including disabling automatic reloads), consistent flashlights (stay turned on even when weapon is not being aimed), more blood when injured, and limping after being injured.
 
@@ -15,6 +15,9 @@ Presently, the following can be customized:
 ***
 ### Development Showcase Video (Showing Version 1.21 Beta)
 [![Watch the Development Showcase video](https://img.youtube.com/vi/NdxUMO0YIJE/maxresdefault.jpg)](https://www.youtube.com/watch?v=NdxUMO0YIJE)
+
+### Development Showcase Video (Showing Version 1.26 Beta)
+[![Watch the Development Showcase video](https://img.youtube.com/vi/HC3lRrcPN4Q/maxresdefault.jpg)](https://www.youtube.com/watch?v=HC3lRrcPN4Q)
 
 > The Inferno Collection Team
 * ChristopherM

--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 # Inferno Collection: Weapons
 [![Build Status](https://travis-ci.com/inferno-collection/Weapons.svg?branch=master)](https://travis-ci.com/inferno-collection/Weapons)
 
-__Public Beta Version 1.21__
+__Public Alpha Version 1.23__
 
 Adds fire modes to the weapons of your choice, as well as more realistic reloads (including disabling automatic reloads), more blood when injured, and limping after being injured.
 
 Presently, the following can be customized:
 - Which weapons have what fire mode.
 - Which weapons do and do not have a reticle.
+- Whether weapons should start on Saftey or semi-automatic
 - Which blood effects are used.
 
 ***
-### Development Showcase Video (Showing Version 1.22 Alpha)
+### Development Showcase Video (Showing Version 1.21 Beta)
 [![Watch the Development Showcase video](https://img.youtube.com/vi/NdxUMO0YIJE/maxresdefault.jpg)](https://www.youtube.com/watch?v=NdxUMO0YIJE)
 
 > The Inferno Collection Team

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 __Public Alpha Version 1.23__
 
-Adds fire modes to the weapons of your choice, as well as more realistic reloads (including disabling automatic reloads), more blood when injured, and limping after being injured.
+Adds fire modes to the weapons of your choice, as well as more realistic reloads (including disabling automatic reloads), consistent flashlights (stay turned on even when weapon is not being aimed), more blood when injured, and limping after being injured.
 
 Presently, the following can be customized:
 - Which weapons have what fire mode.
 - Which weapons do and do not have a reticle.
-- Whether weapons should start on Saftey or semi-automatic
+- Whether weapons should start on Safety or semi-automatic
 - Which blood effects are used.
 
 ***

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Presently, the following can be customized:
 - Which blood effects are used.
 
 ***
-### Development Showcase Video (Showing Version 1.21 Beta)
+### Development Showcase Video (Showing Version 1.22 Alpha)
 [![Watch the Development Showcase video](https://img.youtube.com/vi/NdxUMO0YIJE/maxresdefault.jpg)](https://www.youtube.com/watch?v=NdxUMO0YIJE)
 
 > The Inferno Collection Team

--- a/[inferno-collection]/inferno-weapons/client.lua
+++ b/[inferno-collection]/inferno-weapons/client.lua
@@ -1,4 +1,4 @@
--- Inferno Collection Weapons Version 1.22 Alpha
+-- Inferno Collection Weapons Version 1.23 Alpha
 --
 -- Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 --
@@ -21,6 +21,10 @@ Config.SelectorKey = 26
 
 -- Whether or not to enable selector images when changing fire modes
 Config.SelectorImages = true
+
+-- Whether weapons should start on Safety or semi-automatic
+-- true = Weapons start on Safety, false = weapons start on semi-automatic
+Config.StartSafe = true
 
 -- Weapons variables
 --
@@ -234,7 +238,11 @@ Citizen.CreateThread(function()
 					-- If weapon is not yet logged
 					if FireMode.Weapons[PedWeapon] == nil then
 						-- Log to array
-						FireMode.Weapons[PedWeapon] = 0
+						if Config.StartSafe then
+							FireMode.Weapons[PedWeapon] = 0
+						else
+							FireMode.Weapons[PedWeapon] = 1
+						end
 					end
 
 					-- If fire mode selector key pressed

--- a/[inferno-collection]/inferno-weapons/client.lua
+++ b/[inferno-collection]/inferno-weapons/client.lua
@@ -1,4 +1,4 @@
--- Inferno Collection Weapons Version 1.26 Alpha
+-- Inferno Collection Weapons Version 1.26 Beta
 --
 -- Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 --
@@ -178,7 +178,7 @@ AddEventHandler('playerSpawned', function ()
 	FireMode.LastWeapon = false
 	-- Remove last weapon type
 	FireMode.LastWeaponActive = false
-	-- Remove all active flashlights
+	-- Remove all active local flashlights
 	TriggerServerEvent('Weapons:Server:Toggle', false)
 	FireMode.WeaponFlashlights = {}
 end)
@@ -308,18 +308,14 @@ Citizen.CreateThread(function()
 					end
 
 					-- If fire mode is set to safety
-					if FireMode.Weapons[PedWeapon] == 0 then
-						FireMode.ShootingDisable = true
-					end
+					if FireMode.Weapons[PedWeapon] == 0 then FireMode.ShootingDisable = true end
 
 					local _, Ammo = GetAmmoInClip(PlayerPed, PedWeapon)
 					-- If R was just pressed and client is not already reloading
 					if IsDisabledControlJustPressed(1, 45) and not FireMode.Reloading then
 						FireMode.Reloading = true
 						FireMode.ShootingDisable = true
-						if IsPlayerFreeAiming(PlayerId) then
-							SetPlayerForcedAim(PlayerId, true)
-						end
+						if IsPlayerFreeAiming(PlayerId) then SetPlayerForcedAim(PlayerId, true) end
 						Citizen.Wait(400)
 						MakePedReload(PlayerPed)
 						Citizen.Wait(300)
@@ -333,9 +329,7 @@ Citizen.CreateThread(function()
 						-- Set the ammo in the magazine to one
 						SetAmmoInClip(PlayerPed, PedWeapon, 1)
 						-- If left click just pressed
-						if IsDisabledControlJustPressed(1, 24) then
-							PlaySoundFrontend(-1, 'Faster_Click', 'RESPAWN_ONLINE_SOUNDSET', 1)
-						end
+						if IsDisabledControlJustPressed(1, 24) then PlaySoundFrontend(-1, 'Faster_Click', 'RESPAWN_ONLINE_SOUNDSET', 1) end
 					-- If left click just pressed
 					elseif IsDisabledControlJustPressed(1, 24) then
 						-- If the fire mode is set to safety
@@ -442,6 +436,7 @@ Citizen.CreateThread(function()
 							FireMode.LastWeapon
 						)
 					end
+					
 					RemovedFlashlight = false
 					break
 				end
@@ -549,7 +544,9 @@ end)
 
 -- Updates the synced flashliught variable
 RegisterNetEvent('Weapons:Client:Return')
-AddEventHandler('Weapons:Client:Return', function(NewFlashlights) Flashlights.All = NewFlashlights end)
+AddEventHandler('Weapons:Client:Return', function(NewFlashlights)
+	Flashlights.All = NewFlashlights
+end)
 
 -- NUI function
 function NewNUIMessage (Type, Load)

--- a/[inferno-collection]/inferno-weapons/client.lua
+++ b/[inferno-collection]/inferno-weapons/client.lua
@@ -1,4 +1,4 @@
--- Inferno Collection Weapons Version 1.21 Beta
+-- Inferno Collection Weapons Version 1.22 Alpha
 --
 -- Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 --
@@ -39,7 +39,6 @@ Config.Weapons.Single = {
 	'WEAPON_SNSPISTOL',
 	'WEAPON_HEAVYPISTOL',
 	'WEAPON_VINTAGEPISTOL',
-	'WEAPON_MARKSMANPISTOL',
 	'WEAPON_PUMPSHOTGUN',
 	'WEAPON_SNSPISTOL_MK2',
 	'WEAPON_REVOLVER_MK2'
@@ -289,7 +288,8 @@ Citizen.CreateThread(function()
 						FireMode.ShootingDisable = false
 						FireMode.Reloading = false
 					-- If they is only one bullet left in the magazine
-					elseif Ammo == 1 then
+					-- Or if the firemode is burst, and out of ammo
+					elseif (Ammo == 1 and FireMode.Weapons[PedWeapon] ~= 2) or (Ammo <= 3 and FireMode.Weapons[PedWeapon] == 2) then
 						FireMode.ShootingDisable = true
 						-- Set the ammo in the magazine to one
 						SetAmmoInClip(PlayerPed, PedWeapon, 1)

--- a/[inferno-collection]/inferno-weapons/client.lua
+++ b/[inferno-collection]/inferno-weapons/client.lua
@@ -436,7 +436,7 @@ Citizen.CreateThread(function()
 							FireMode.LastWeapon
 						)
 					end
-					
+
 					RemovedFlashlight = false
 					break
 				end

--- a/[inferno-collection]/inferno-weapons/fxmanifest.lua
+++ b/[inferno-collection]/inferno-weapons/fxmanifest.lua
@@ -1,4 +1,4 @@
--- Inferno Collection Weapons Version 1.26 Alpha
+-- Inferno Collection Weapons Version 1.26 Beta
 --
 -- Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 --
@@ -10,11 +10,11 @@
 
 name 'Weapons - Inferno Collection'
 
-description 'Adds fire modes to the weapons of your choice, as well as more realistic reloads (including disabling automatic reloads), more blood when injured, and limping after being injured.'
+description 'Adds fire modes to the weapons of your choice, as well as more realistic reloads (including disabling automatic reloads), consistent flashlights (stay turned on even when weapon is not being aimed), more blood when injured, and limping after being injured.'
 
 author 'Inferno Collection (inferno-collection.com)'
 
-version '1.26 Alpha'
+version '1.26 Beta'
 
 url 'https://inferno-collection.com'
 

--- a/[inferno-collection]/inferno-weapons/fxmanifest.lua
+++ b/[inferno-collection]/inferno-weapons/fxmanifest.lua
@@ -1,4 +1,4 @@
--- Inferno Collection Weapons Version 1.24 Alpha
+-- Inferno Collection Weapons Version 1.25 Alpha
 --
 -- Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 --
@@ -14,7 +14,7 @@ description 'Adds fire modes to the weapons of your choice, as well as more real
 
 author 'Inferno Collection (inferno-collection.com)'
 
-version '1.24 Alpha'
+version '1.25 Alpha'
 
 url 'https://inferno-collection.com'
 

--- a/[inferno-collection]/inferno-weapons/fxmanifest.lua
+++ b/[inferno-collection]/inferno-weapons/fxmanifest.lua
@@ -1,4 +1,4 @@
--- Inferno Collection Weapons Version 1.21 Beta
+-- Inferno Collection Weapons Version 1.22 Alpha
 --
 -- Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 --
@@ -14,7 +14,7 @@ description 'Adds fire modes to the weapons of your choice, as well as more real
 
 author 'Inferno Collection (inferno-collection.com)'
 
-version '1.21 Beta'
+version '1.22 Alpha'
 
 url 'https://inferno-collection.com'
 

--- a/[inferno-collection]/inferno-weapons/fxmanifest.lua
+++ b/[inferno-collection]/inferno-weapons/fxmanifest.lua
@@ -1,4 +1,4 @@
--- Inferno Collection Weapons Version 1.25 Alpha
+-- Inferno Collection Weapons Version 1.26 Alpha
 --
 -- Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 --
@@ -14,7 +14,7 @@ description 'Adds fire modes to the weapons of your choice, as well as more real
 
 author 'Inferno Collection (inferno-collection.com)'
 
-version '1.25 Alpha'
+version '1.26 Alpha'
 
 url 'https://inferno-collection.com'
 

--- a/[inferno-collection]/inferno-weapons/fxmanifest.lua
+++ b/[inferno-collection]/inferno-weapons/fxmanifest.lua
@@ -1,4 +1,4 @@
--- Inferno Collection Weapons Version 1.22 Alpha
+-- Inferno Collection Weapons Version 1.23 Alpha
 --
 -- Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 --
@@ -14,7 +14,7 @@ description 'Adds fire modes to the weapons of your choice, as well as more real
 
 author 'Inferno Collection (inferno-collection.com)'
 
-version '1.22 Alpha'
+version '1.23 Alpha'
 
 url 'https://inferno-collection.com'
 

--- a/[inferno-collection]/inferno-weapons/nui.html
+++ b/[inferno-collection]/inferno-weapons/nui.html
@@ -1,5 +1,5 @@
 <!--
-Inferno Collection Weapons Version 1.21 Beta
+Inferno Collection Weapons Version 1.22 Alpha
 
 Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 

--- a/[inferno-collection]/inferno-weapons/nui.html
+++ b/[inferno-collection]/inferno-weapons/nui.html
@@ -1,5 +1,5 @@
 <!--
-Inferno Collection Weapons Version 1.23 Alpha
+Inferno Collection Weapons Version 1.24 Alpha
 
 Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 

--- a/[inferno-collection]/inferno-weapons/nui.html
+++ b/[inferno-collection]/inferno-weapons/nui.html
@@ -1,5 +1,5 @@
 <!--
-Inferno Collection Weapons Version 1.25 Alpha
+Inferno Collection Weapons Version 1.26 Alpha
 
 Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 

--- a/[inferno-collection]/inferno-weapons/nui.html
+++ b/[inferno-collection]/inferno-weapons/nui.html
@@ -1,5 +1,5 @@
 <!--
-Inferno Collection Weapons Version 1.22 Alpha
+Inferno Collection Weapons Version 1.23 Alpha
 
 Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 

--- a/[inferno-collection]/inferno-weapons/nui.html
+++ b/[inferno-collection]/inferno-weapons/nui.html
@@ -1,5 +1,5 @@
 <!--
-Inferno Collection Weapons Version 1.26 Alpha
+Inferno Collection Weapons Version 1.26 Beta
 
 Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 

--- a/[inferno-collection]/inferno-weapons/nui.html
+++ b/[inferno-collection]/inferno-weapons/nui.html
@@ -1,5 +1,5 @@
 <!--
-Inferno Collection Weapons Version 1.24 Alpha
+Inferno Collection Weapons Version 1.25 Alpha
 
 Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 

--- a/[inferno-collection]/inferno-weapons/server.lua
+++ b/[inferno-collection]/inferno-weapons/server.lua
@@ -1,4 +1,4 @@
--- Inferno Collection Weapons Version 1.26 Alpha
+-- Inferno Collection Weapons Version 1.26 Beta
 --
 -- Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 --
@@ -23,9 +23,9 @@ end)
 
 -- Toggle client flashlight status
 RegisterServerEvent('Weapons:Server:Toggle')
-AddEventHandler('Weapons:Server:Toggle', function(bool, flashlight)
+AddEventHandler('Weapons:Server:Toggle', function(bool, flashlight, weapon)
     if bool then
-        Flashlights[source] = flashlight
+        Flashlights[source] = {flashlight, weapon}
     else
         Flashlights[source] = nil
     end

--- a/[inferno-collection]/inferno-weapons/server.lua
+++ b/[inferno-collection]/inferno-weapons/server.lua
@@ -1,4 +1,4 @@
--- Inferno Collection Weapons Version 1.24 Alpha
+-- Inferno Collection Weapons Version 1.25 Alpha
 --
 -- Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 --
@@ -16,9 +16,15 @@
 -- Master Flashlight storage variable
 local Flashlights = {}
 
--- Adds new flashlight request to array
-RegisterServerEvent('Weapons:Server:New')
-AddEventHandler('Weapons:Server:New', function(x1, y1, z1, x2, y2, z2) Flashlights[source] = {x1, y1, z1, x2, y2, z2} end)
+-- Toggle client flashlight status
+RegisterServerEvent('Weapons:Server:Toggle')
+AddEventHandler('Weapons:Server:Toggle', function(bool, flashlight)
+    if bool then
+        Flashlights[source] = flashlight
+    else
+        Flashlights[source] = nil
+    end
+end)
 
 Citizen.CreateThread(function()
     while true do
@@ -26,7 +32,5 @@ Citizen.CreateThread(function()
 
         -- Updates all clients for this tick
         TriggerClientEvent('Weapons:Client:Return', -1, Flashlights)
-        -- Clears the variable ready to be updated next tick
-        Flashlights = {}
     end
 end)

--- a/[inferno-collection]/inferno-weapons/server.lua
+++ b/[inferno-collection]/inferno-weapons/server.lua
@@ -8,27 +8,25 @@
 -- THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. THE SOFTWARE MAY NOT BE SOLD.
 --
 
-name 'Weapons - Inferno Collection'
+--
+--		Nothing past this point needs to be edited, all the settings for the resource are found ABOVE this line.
+--		Do not make changes below this line unless you know what you are doing!
+--
 
-description 'Adds fire modes to the weapons of your choice, as well as more realistic reloads (including disabling automatic reloads), more blood when injured, and limping after being injured.'
+-- Master Flashlight storage variable
+local Flashlights = {}
 
-author 'Inferno Collection (inferno-collection.com)'
+-- Adds new flashlight request to array
+RegisterServerEvent('Weapons:Server:New')
+AddEventHandler('Weapons:Server:New', function(x1, y1, z1, x2, y2, z2) Flashlights[source] = {x1, y1, z1, x2, y2, z2} end)
 
-version '1.24 Alpha'
+Citizen.CreateThread(function()
+    while true do
+        Citizen.Wait(0)
 
-url 'https://inferno-collection.com'
-
-client_script 'client.lua'
-
-server_script 'server.lua'
-
-files {
-    'nui.html',
-    'images/*.png'
-}
-
-ui_page 'nui.html'
-
-game 'gta5'
-
-fx_version 'bodacious'
+        -- Updates all clients for this tick
+        TriggerClientEvent('Weapons:Client:Return', -1, Flashlights)
+        -- Clears the variable ready to be updated next tick
+        Flashlights = {}
+    end
+end)

--- a/[inferno-collection]/inferno-weapons/server.lua
+++ b/[inferno-collection]/inferno-weapons/server.lua
@@ -1,4 +1,4 @@
--- Inferno Collection Weapons Version 1.25 Alpha
+-- Inferno Collection Weapons Version 1.26 Alpha
 --
 -- Copyright (c) 2019-2020, Christopher M, Inferno Collection. All rights reserved.
 --
@@ -15,6 +15,11 @@
 
 -- Master Flashlight storage variable
 local Flashlights = {}
+
+-- Remove flashlights of players who are no longer in server
+AddEventHandler('playerDropped', function ()
+    if Flashlights[source] then Flashlights[source] = nil end
+end)
 
 -- Toggle client flashlight status
 RegisterServerEvent('Weapons:Server:Toggle')


### PR DESCRIPTION
Added:
- Consistent flashlights
    - Works by pressing E when holding a gun with a flashlight attachment, this will turn the flashlight on, even when not aiming.
- Config option for weapons to start on Safety or semi-automatic.

Fixed:
- Being able to auto-reload when using burst mode.

Changed:
- Added a variable for `PlayerId` in the master loop, to avoid calling it 4 times.

Removed:
- Marksman pistol from `Single` list, since it is a single shot weapon and does not work with the script.